### PR TITLE
Make ControllerListenerWrapper nullsafe and ignore ControllerListener…

### DIFF
--- a/vito/drawee-support/src/main/java/com/facebook/fresco/vito/draweesupport/ControllerListenerWrapper.java
+++ b/vito/drawee-support/src/main/java/com/facebook/fresco/vito/draweesupport/ControllerListenerWrapper.java
@@ -7,6 +7,8 @@
 
 package com.facebook.fresco.vito.draweesupport;
 
+import static com.facebook.infer.annotation.Assertions.nullsafeFIXME;
+
 import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import androidx.annotation.VisibleForTesting;
@@ -16,8 +18,10 @@ import com.facebook.fresco.ui.common.DimensionsInfo;
 import com.facebook.fresco.ui.common.OnDrawControllerListener;
 import com.facebook.fresco.vito.listener.ImageListener;
 import com.facebook.imagepipeline.image.ImageInfo;
+import com.facebook.infer.annotation.Nullsafe;
 import javax.annotation.Nullable;
 
+@Nullsafe(Nullsafe.Mode.LOCAL)
 public class ControllerListenerWrapper implements ImageListener {
 
   /**
@@ -40,8 +44,9 @@ public class ControllerListenerWrapper implements ImageListener {
   }
 
   @Override
-  public void onSubmit(long id, Object callerContext) {
-    mControllerListener.onSubmit(toStringId(id), callerContext);
+  public void onSubmit(long id, @Nullable Object callerContext) {
+    mControllerListener.onSubmit(
+        toStringId(id), nullsafeFIXME(callerContext, "Legacy ControllerListener is not nullsafe"));
   }
 
   @Override
@@ -65,13 +70,15 @@ public class ControllerListenerWrapper implements ImageListener {
   }
 
   @Override
-  public void onIntermediateImageFailed(long id, Throwable throwable) {
-    mControllerListener.onIntermediateImageFailed(toStringId(id), throwable);
+  public void onIntermediateImageFailed(long id, @Nullable Throwable throwable) {
+    mControllerListener.onIntermediateImageFailed(
+        toStringId(id), nullsafeFIXME(throwable, "Legacy ControllerListener is not nullsafe"));
   }
 
   @Override
-  public void onFailure(long id, @Nullable Drawable error, Throwable throwable) {
-    mControllerListener.onFailure(toStringId(id), throwable);
+  public void onFailure(long id, @Nullable Drawable error, @Nullable Throwable throwable) {
+    mControllerListener.onFailure(
+        toStringId(id), nullsafeFIXME(throwable, "Legacy ControllerListener is not nullsafe"));
   }
 
   @Override


### PR DESCRIPTION
… issues

Summary: We're making Fresco Vito nullsafe, however the old Drawee ControllerListener doesn't have proper Nullable annotations yet and it's a breaking API change, so let's ignore them for now.

Reviewed By: wizh

Differential Revision: D29333952

fbshipit-source-id: 1fbf3a3cf8136f5de91fd832a6144aa964352b0f

Thanks for submitting a PR! Please read these instructions carefully:

- [ ] Explain the **motivation** for making this change.
- [ ] Provide a **test plan** demonstrating that the code is solid.
- [ ] Match the **code formatting** of the rest of the codebase.
- [ ] Target the `master` branch

## Motivation (required)

What existing problem does the pull request solve?

## Test Plan (required)

A good test plan has the exact commands you ran and their output, provides screenshots or videos if the pull request changes UI or updates the website. See [What is a Test Plan?][1] to learn more.  

If you have added code that should be tested, add tests.

## Next Steps

Sign the [CLA][2], if you haven't already.

Small pull requests are much easier to review and more likely to get merged. Make sure the PR does only one thing, otherwise please split it.

Make sure all **tests pass** on [Circle CI][4]. PRs that break tests are unlikely to be merged.

For more info, see the [Contributing guide][4].

[1]: https://medium.com/@martinkonicek/what-is-a-test-plan-8bfc840ec171#.y9lcuqqi9
[2]: https://code.facebook.com/cla
[3]: http://circleci.com/gh/facebook/fresco
[4]: https://github.com/facebook/fresco/blob/master/CONTRIBUTING.md
